### PR TITLE
Ensure protocol is a string

### DIFF
--- a/lib/rails/deprecated_sanitizer/html-scanner/html/sanitizer.rb
+++ b/lib/rails/deprecated_sanitizer/html-scanner/html/sanitizer.rb
@@ -182,7 +182,7 @@ module HTML
 
     def contains_bad_protocols?(attr_name, value)
       uri_attributes.include?(attr_name) &&
-      (value =~ /(^[^\/:]*):|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/i && !allowed_protocols.include?(value.split(protocol_separator).first.downcase.strip))
+      (value =~ /(^[^\/:]*):|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/i && !allowed_protocols.include?(value.split(protocol_separator).first.to_s.downcase.strip))
     end
   end
 end

--- a/test/protocol_test.rb
+++ b/test/protocol_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class ProtocolTest < ActiveSupport::TestCase
+  def test_sanitize_protocol_separator
+    sanitizer = HTML::WhiteListSanitizer.new
+    string = '<a href=":">bad link</a>'
+
+    assert_equal '<a>bad link</a>', sanitizer.sanitize(string)
+  end
+end


### PR DESCRIPTION
This should prevent exceptions when a protocol consists solely of a separator character (e.g. `:`). I'm not sure if this project is still accepting contributions, but I thought it worthwhile to document in any case.
